### PR TITLE
Add priority to recipients

### DIFF
--- a/src/main/java/uk/co/fivium/dmda/emailmessages/DatabaseMessageStorer.java
+++ b/src/main/java/uk/co/fivium/dmda/emailmessages/DatabaseMessageStorer.java
@@ -101,25 +101,23 @@ public class DatabaseMessageStorer implements MessageStorer{
   private void storeMessageBody(EmailMessage pEmailMessage, String lDatabaseName, OraclePreparedStatement pStatement, String pStoreQuery)
   throws SQLException, ParserConfigurationException {
     for (EmailRecipient lRecipient : pEmailMessage.getRecipients()){
-      for (String recipientDatabase : SMTPConfig.getInstance().getDatabasesForRecipient(lRecipient.mDomain)) {
-        if (lDatabaseName.equals(recipientDatabase)) {
-          // Bind values to the bind variables if they exist in the store query.
-          setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.MAIL_ID.getText(), pEmailMessage.getMailId());
-          setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.USER.getText(), lRecipient.mUser);
-          setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.FROM.getText(), pEmailMessage.getFrom());
-          setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.RECIPIENT.getText(), lRecipient.mEmailAddress);
-          setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.REMOTE_HOSTNAME.getText(),
-              pEmailMessage.getRemoteHostname());
-          setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.REMOTE_ADDRESS.getText(),
-              pEmailMessage.getRemoteAddress());
-          setBlobAtNameIfExists(pStoreQuery, pStatement, BindParams.MESSAGE_BODY.getText(),
-              pEmailMessage.getDataStream());
-          setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.SUBJECT.getText(), pEmailMessage.getSubject());
-          setDateAtNameIfExists(pStoreQuery, pStatement, BindParams.SENT_DATE.getText(), pEmailMessage.getSentDate());
-          setHeaderBindIfExists(pStoreQuery, pStatement, pEmailMessage);
+      if (SMTPConfig.getInstance().getDatabasesForRecipient(lRecipient.mDomain).contains(lDatabaseName)) {
+        // Bind values to the bind variables if they exist in the store query.
+        setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.MAIL_ID.getText(), pEmailMessage.getMailId());
+        setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.USER.getText(), lRecipient.mUser);
+        setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.FROM.getText(), pEmailMessage.getFrom());
+        setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.RECIPIENT.getText(), lRecipient.mEmailAddress);
+        setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.REMOTE_HOSTNAME.getText(),
+            pEmailMessage.getRemoteHostname());
+        setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.REMOTE_ADDRESS.getText(),
+            pEmailMessage.getRemoteAddress());
+        setBlobAtNameIfExists(pStoreQuery, pStatement, BindParams.MESSAGE_BODY.getText(),
+            pEmailMessage.getDataStream());
+        setStringAtNameIfExists(pStoreQuery, pStatement, BindParams.SUBJECT.getText(), pEmailMessage.getSubject());
+        setDateAtNameIfExists(pStoreQuery, pStatement, BindParams.SENT_DATE.getText(), pEmailMessage.getSentDate());
+        setHeaderBindIfExists(pStoreQuery, pStatement, pEmailMessage);
 
-          pStatement.execute();
-        }
+        pStatement.execute();
       }
     }
   }

--- a/src/main/java/uk/co/fivium/dmda/server/DomainMatcher.java
+++ b/src/main/java/uk/co/fivium/dmda/server/DomainMatcher.java
@@ -6,10 +6,13 @@ public class DomainMatcher{
     private String mDomain;
     private boolean mRegex;
     private String mDatabase;
-    public DomainMatcher(String pDomain , boolean pRegex, String pDatebase){
+    private int mPriority;
+
+    public DomainMatcher(String pDomain, boolean pRegex, String pDatebase, int pPriority){
         mDomain  = pDomain;
         mRegex = pRegex;
         mDatabase = pDatebase;
+        mPriority = pPriority;
     }
 
     public boolean match(String pDomain){
@@ -18,5 +21,9 @@ public class DomainMatcher{
 
     public String getDatabase(){
         return mDatabase;
+    }
+
+    public int getPriority() {
+        return mPriority;
     }
 }

--- a/src/test/java/uk/co/fivium/dmda/emailmessages/TestPriorityRecipients.java
+++ b/src/test/java/uk/co/fivium/dmda/emailmessages/TestPriorityRecipients.java
@@ -1,0 +1,42 @@
+package uk.co.fivium.dmda.emailmessages;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import uk.co.fivium.dmda.TestUtil;
+import uk.co.fivium.dmda.server.ConfigurationException;
+import uk.co.fivium.dmda.server.SMTPConfig;
+
+public class TestPriorityRecipients {
+  SMTPConfig mConfig;
+
+  @Before
+  public void loadConfig() throws ConfigurationException {
+    mConfig = SMTPConfig.getInstance();
+    mConfig.loadConfig(TestUtil.getTestResourceFile("priority_config.xml", this.getClass()));
+  }
+
+  @Test
+  public void testDuplicatePriorities(){
+    List<String> lDatabaseNames = mConfig.getDatabasesForRecipient("exact.domain.co.uk");
+    assertEquals(2, lDatabaseNames.size());
+    assertTrue(lDatabaseNames.contains("db1"));
+    assertTrue(lDatabaseNames.contains("db2"));
+  }
+  @Test
+  public void testCorrectMatching(){
+    List<String> lDatabaseNames = mConfig.getDatabasesForRecipient("not_exact.domain.co.uk");
+    assertEquals(1, lDatabaseNames.size());
+    assertTrue(lDatabaseNames.contains("db3"));
+  }
+  @Test
+  public void testDefault(){
+    List<String> lDatabaseNames = mConfig.getDatabasesForRecipient("not.exact.co.uk");
+    assertEquals(1, lDatabaseNames.size());
+    assertTrue(lDatabaseNames.contains("db4"));
+  }
+
+}

--- a/src/test/java/uk/co/fivium/dmda/emailmessages/TestWildCardRecipients.java
+++ b/src/test/java/uk/co/fivium/dmda/emailmessages/TestWildCardRecipients.java
@@ -1,5 +1,6 @@
 package uk.co.fivium.dmda.emailmessages;
 
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import uk.co.fivium.dmda.server.ConfigurationException;
@@ -7,6 +8,7 @@ import uk.co.fivium.dmda.server.SMTPConfig;
 import uk.co.fivium.dmda.TestUtil;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestWildCardRecipients {
   SMTPConfig mConfig;
@@ -22,18 +24,24 @@ public class TestWildCardRecipients {
   */
   @Test
   public void testExactDomain(){
-    String lDatabaseName = mConfig.getDatabaseForRecipient("exact.domain.co.uk");
-    assertEquals("db1", lDatabaseName);
+    List<String> lDatabaseNames = mConfig.getDatabasesForRecipient("exact.domain.co.uk");
+    assertEquals(3, lDatabaseNames.size());
+    assertTrue(lDatabaseNames.contains("db1"));
+    assertTrue(lDatabaseNames.contains("db2"));
+    assertTrue(lDatabaseNames.contains("db3"));
   }
   @Test
   public void testFuzzyDomainMatch(){
-    String lDatabaseName = mConfig.getDatabaseForRecipient("not_exact.domain.co.uk");
-    assertEquals("db2", lDatabaseName);
+    List<String> lDatabaseNames = mConfig.getDatabasesForRecipient("not_exact.domain.co.uk");
+    assertEquals(2, lDatabaseNames.size());
+    assertTrue(lDatabaseNames.contains("db2"));
+    assertTrue(lDatabaseNames.contains("db3"));
   }
   @Test
   public void testAnyDomainMatch(){
-    String lDatabaseName = mConfig.getDatabaseForRecipient("not.exact.co.uk");
-    assertEquals("db3", lDatabaseName);
+    List<String> lDatabaseNames = mConfig.getDatabasesForRecipient("not.exact.co.uk");
+    assertEquals(1, lDatabaseNames.size());
+    assertTrue(lDatabaseNames.contains("db3"));
   }
 
 }

--- a/src/test/resources/uk/co/fivium/dmda/emailmessages/priority_config.xml
+++ b/src/test/resources/uk/co/fivium/dmda/emailmessages/priority_config.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<smtp_config>
+    <!-- The port the server will listen on. Default 2601. -->
+    <port>2601</port>
+    <!-- Logging level can be set to debug, info or error -->
+    <logging_level>info</logging_level>
+    <!-- Logging mode can be set to console or file -->
+    <logging_mode>console</logging_mode>
+    <!-- The generic message that is used when an email is rejected -->
+    <email_rejection_message>An unexpected error has occurred and your email has not been received. Please try again
+        later.
+    </email_rejection_message>
+    <!-- The max size the message body can be in megabytes, default 15MB -->
+    <message_size_limit_mb>50</message_size_limit_mb>
+    <!-- AV can be disabled by setting the mode to 'none' -->
+    <anti_virus>
+        <mode>none</mode>
+    </anti_virus>
+    <!-- The list of databases. Databases have a many to 1 relationship with recipients. -->
+    <database_list>
+        <database>
+            <name>db1</name>
+            <jdbc_url>jdbc:oracle:thin:@database.local:1521:db1</jdbc_url>
+            <username>SCHEMA</username>
+            <password>password</password>
+            <store_query>Some Store Query</store_query>
+        </database>
+        <database>
+            <name>db2</name>
+            <jdbc_url>jdbc:oracle:thin:@database.local:1521:db2</jdbc_url>
+            <username>SCHEMA</username>
+            <password>password</password>
+            <store_query>Some Store Query</store_query>
+        </database>
+        <database>
+            <name>db3</name>
+            <jdbc_url>jdbc:oracle:thin:@database.local:1521:db3</jdbc_url>
+            <username>SCHEMA</username>
+            <password>password</password>
+            <store_query>Some Store Query</store_query>
+        </database>
+        <database>
+            <name>db4</name>
+            <jdbc_url>jdbc:oracle:thin:@database.local:1521:db4</jdbc_url>
+            <username>SCHEMA</username>
+            <password>password</password>
+            <store_query>Some Store Query</store_query>
+        </database>
+    </database_list>
+    <!-- The recipient list has a many to 1 relationship with the databases above. -->
+    <recipient_list>
+        <recipient>
+            <domain>exact.domain.co.uk</domain>
+            <database>db1</database>
+            <priority>10</priority>
+        </recipient>
+        <recipient>
+            <domain_regex>exact.domain.co.uk</domain_regex>
+            <database>db2</database>
+            <priority>10</priority>
+        </recipient>
+        <recipient>
+            <domain_regex>.*\.domain\.co\.uk</domain_regex>
+            <database>db3</database>
+            <priority>20</priority>
+        </recipient>
+        <recipient>
+            <domain_regex>.*</domain_regex>
+            <database>db4</database>
+        </recipient>
+    </recipient_list>
+</smtp_config>


### PR DESCRIPTION
This also includes a breaking change where previously if an email matched multiple domains it would return the first listed in the config, but now it will return all matches if they have equal (or no) priority.