### PR TITLE
Add option to read anti-virus config from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ folder you run the following command:
 
 `java -jar ./target/dmda-x.x-SNAPSHOT-jar-with-dependencies.jar`
 
+
+Configuration
+--------------------------------------
+All application configuration is defined in the `config.xml` file, with the exception of anti-virus connection information which can also be configured via the following environment variables.
+
+|Name|Description|
+|---|---|
+|`DMDA_AV_MODE`|The anti-virus mode. One of `clamd` or `none`.|
+|`DMDA_AV_SERVER`|The anti-virus server hostname.|
+|`DMDA_AV_PORT`|The anti-virus server port.|
+|`DMDA_AV_TIMEOUT_MS`|The anti-virus scan timeout in milliseconds.|
+
+If anti-virus configuration exists in both environment variables and the XML config file, the configuration options set in the environment variables will take precedence.
+
+See the [sample config file](https://github.com/Fivium/DMDA/blob/master/config.xml.sample) for all other options.
+
 Health Checks
 --------------------------------------
 DMDA provides the following basic application health checks, which can be queried over HTTP.
@@ -39,22 +55,3 @@ Note that these endpoints should only be exposed locally to monitoring tools suc
 Requirements
 --------------------------------------
 - Java : >=1.8
-
-Building
---------------------------------------
-Due to Oracle licensing terms DMDA cannot re-distribute the Oracle JDBC jar files needed for building DMDA.
-Instead you need to have a valid Oracle Database install to get the Oracle JDBC jar available in the following 
-location, depending upon Oracle version:
-
-**Oracle 11g**: `$ORACLE_HOME/jdbc/lib/ojdbc6.jar`
-
-**Oracle 12c**: `$ORACLE_HOME/jdbc/lib/ojdbc6.jar`
-
-Once you have the jar you should add it to your local maven install using the following command:
-
-`mvn install:install-file 
-  -Dfile=ojdbc6.jar 
-  -DgroupId=com.oracle.jdbc 
-  -DartifactId=ojdbc6 
-  -Dversion=11.2.0.4 
-  -Dpackaging=jar`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.co.fivium</groupId>
   <artifactId>dmda</artifactId>
-  <version>1.5-SNAPSHOT</version>
+  <version>1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>dmda</name>
   <properties>
@@ -29,7 +29,7 @@
         <configuration>
           <archive>
             <manifest>
-              <mainClass>uk.co.fivium.dmda.server.SMTPStart</mainClass>
+              <mainClass>uk.co.fivium.dmda.Server.SMTPStart</mainClass>
             </manifest>
           </archive>
         </configuration>
@@ -41,7 +41,7 @@
         <configuration>
           <archive>
             <manifest>
-              <mainClass>uk.co.fivium.dmda.server.SMTPStart</mainClass>
+              <mainClass>uk.co.fivium.dmda.Server.SMTPStart</mainClass>
             </manifest>
           </archive>
           <descriptorRefs>
@@ -54,25 +54,6 @@
             <phase>package</phase>
             <goals>
               <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.1</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
             </goals>
           </execution>
         </executions>
@@ -100,9 +81,8 @@
       <artifactId>subethasmtp</artifactId>
       <version>3.1.7</version>
     </dependency>
-    <!-- Make sure you run `mvn install:install-file -Dfile=ojdbc6-11.2.0.4.jar -DgroupId=com.oracle.jdbc -DartifactId=ojdbc6 -Dversion=11.2.0.4 -Dpackaging=jar` first -->
     <dependency>
-      <groupId>com.oracle.jdbc</groupId>
+      <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc6</artifactId>
       <version>11.2.0.4</version>
     </dependency>
@@ -110,6 +90,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-lambda</artifactId>
+      <version>1.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.co.fivium</groupId>
   <artifactId>dmda</artifactId>
-  <version>1.4-SNAPSHOT</version>
+  <version>1.5-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>dmda</name>
   <properties>
@@ -29,7 +29,7 @@
         <configuration>
           <archive>
             <manifest>
-              <mainClass>uk.co.fivium.dmda.Server.SMTPStart</mainClass>
+              <mainClass>uk.co.fivium.dmda.server.SMTPStart</mainClass>
             </manifest>
           </archive>
         </configuration>
@@ -41,7 +41,7 @@
         <configuration>
           <archive>
             <manifest>
-              <mainClass>uk.co.fivium.dmda.Server.SMTPStart</mainClass>
+              <mainClass>uk.co.fivium.dmda.server.SMTPStart</mainClass>
             </manifest>
           </archive>
           <descriptorRefs>
@@ -54,6 +54,25 @@
             <phase>package</phase>
             <goals>
               <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/java/uk/co/fivium/dmda/server/SMTPConfig.java
+++ b/src/main/java/uk/co/fivium/dmda/server/SMTPConfig.java
@@ -115,13 +115,13 @@ public class SMTPConfig {
     String lEnvAVMode = System.getenv("DMDA_AV_MODE");
     Optional<Element> lXmlAVConfig = getUniqueChildElementIfExists(pRootElement, "anti_virus");
 
-    if(lEnvAVMode != null) {
-      if(lXmlAVConfig.isPresent()) {
+    if (lEnvAVMode != null) {
+      if (lXmlAVConfig.isPresent()) {
         LOGGER.warn("Anti-virus config found in both environment variables and XML config file. Environment variables will take precedence.");
       }
       loadAVConfigFromEnv(lEnvAVMode);
     }
-    else if(lXmlAVConfig.isPresent()){
+    else if (lXmlAVConfig.isPresent()){
       loadAVConfigFromXML(lXmlAVConfig.get());
     }
     else {

--- a/src/main/java/uk/co/fivium/dmda/server/SMTPConfig.java
+++ b/src/main/java/uk/co/fivium/dmda/server/SMTPConfig.java
@@ -1,8 +1,5 @@
 package uk.co.fivium.dmda.server;
 
-import static java.util.stream.Collectors.toList;
-
-import java.util.Comparator;
 import org.apache.log4j.Appender;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.FileAppender;
@@ -39,10 +36,13 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.stream.Collectors.toList;
+
 /**
  * Singleton for parsing and holding configuration data for DMDA
  */
 public class SMTPConfig {
+  private static final Logger LOGGER = Logger.getLogger(SMTPConfig.class);
   public static final int BYTES_IN_MEGABYTE = 1000 * 1000;
 
   private static final SMTPConfig gSMTPConfig  = new SMTPConfig();
@@ -112,13 +112,43 @@ public class SMTPConfig {
 
   private void loadAVConfig(Element pRootElement)
   throws ConfigurationException {
-    Element lAVConfig = getUniqueChildElement(pRootElement, "anti_virus");
-    mAVMode = getUniqueChildNodeText(lAVConfig, "mode");
+    String lEnvAVMode = System.getenv("DMDA_AV_MODE");
+    Optional<Element> lXmlAVConfig = getUniqueChildElementIfExists(pRootElement, "anti_virus");
 
+    if(lEnvAVMode != null) {
+      if(lXmlAVConfig.isPresent()) {
+        LOGGER.warn("Anti-virus config found in both environment variables and XML config file. Environment variables will take precedence.");
+      }
+      loadAVConfigFromEnv(lEnvAVMode);
+    }
+    else if(lXmlAVConfig.isPresent()){
+      loadAVConfigFromXML(lXmlAVConfig.get());
+    }
+    else {
+      throw new ConfigurationException("No anti-virus configuration found in environment variables or XML config");
+    }
+  }
+
+  private void loadAVConfigFromEnv(String pAVMode)
+  throws ConfigurationException {
+    mAVMode = pAVMode;
     if (AVModes.CLAM.getText().equals(mAVMode)) {
-      mAVPort = getUniqueChildNodeInt(lAVConfig, "port");
-      mAVServer = getUniqueChildNodeText(lAVConfig, "server");
-      mAVTimeoutMS = getUniqueChildNodeInt(lAVConfig, "timeout_ms");
+      mAVPort = getEnvVarInt("DMDA_AV_PORT");
+      mAVServer = getEnvVar("DMDA_AV_SERVER");
+      mAVTimeoutMS = getEnvVarInt("DMDA_AV_TIMEOUT_MS");
+    }
+    else if (!AVModes.NONE.getText().equals(mAVMode)){
+      throw new ConfigurationException("Unknown anti-virus mode " + mAVMode);
+    }
+  }
+
+  private void loadAVConfigFromXML(Element pAVConfigElement)
+  throws ConfigurationException {
+    mAVMode = getUniqueChildNodeText(pAVConfigElement, "mode");
+    if (AVModes.CLAM.getText().equals(mAVMode)) {
+      mAVPort = getUniqueChildNodeInt(pAVConfigElement, "port");
+      mAVServer = getUniqueChildNodeText(pAVConfigElement, "server");
+      mAVTimeoutMS = getUniqueChildNodeInt(pAVConfigElement, "timeout_ms");
     }
     else if (!AVModes.NONE.getText().equals(mAVMode)){
       throw new ConfigurationException("Unknown anti-virus mode " + mAVMode);
@@ -465,6 +495,20 @@ public class SMTPConfig {
   private int getUniqueChildNodeInt(Element pElement, String pChildTagName)
   throws ConfigurationException {
     return Integer.parseInt(getUniqueChildNodeText(pElement, pChildTagName));
+  }
+
+  private String getEnvVar(String pEnvVarName)
+    throws ConfigurationException {
+    String lVar = System.getenv(pEnvVarName);
+    if (lVar == null) {
+      throw new ConfigurationException("Environment variable " + pEnvVarName + " not set");
+    }
+    return lVar;
+  }
+
+  private int getEnvVarInt(String pEnvVarName)
+    throws ConfigurationException {
+    return Integer.parseInt(getEnvVar(pEnvVarName));
   }
 
   /**

--- a/src/test/resources/uk/co/fivium/dmda/server/no_av_config.xml
+++ b/src/test/resources/uk/co/fivium/dmda/server/no_av_config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<smtp_config>
+  <!-- The port the server will listen on. Default 2601. -->
+  <port>2601</port>
+  <!-- Logging level can be set to debug, info or error -->
+  <logging_level>info</logging_level>
+  <!-- Logging mode can be set to console or file -->
+  <logging_mode>console</logging_mode>
+  <!-- The generic message that is used when an email is rejected -->
+  <email_rejection_message>An unexpected error has occurred and your email has not been received. Please try again
+    later.
+  </email_rejection_message>
+  <!-- The max size the message body can be in megabytes, default 15MB -->
+  <message_size_limit_mb>50</message_size_limit_mb>
+  <!-- The list of databases. Databases have a many to 1 relationship with recipients. -->
+  <database_list>
+    <database>
+      <name>db1</name>
+      <jdbc_url>jdbc:oracle:thin:@database.local:1521:db1</jdbc_url>
+      <username>SCHEMA</username>
+      <password>password</password>
+      <store_query>Some Store Query</store_query>
+    </database>
+  </database_list>
+  <!-- The recipient list has a many to 1 relationship with the databases above. -->
+  <recipient_list>
+    <recipient>
+      <domain>exact.domain.co.uk</domain>
+      <database>db1</database>
+    </recipient>
+  </recipient_list>
+</smtp_config>


### PR DESCRIPTION
This adds support for reading AV config from environment variables. This has been requested by ops so that config can be dynamically set using swarm service templates, which can only be set in the compose file and so can't be referenced currently in the xml config file.

I haven't made the whole config configurable via the env as most of the xml config takes repeating lists of complex elements which don't translate well to env vars